### PR TITLE
feat: make committer mismatch message more informative

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,20 +11,15 @@
     "dist/**",
     "node_modules/**"
   ],
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
   "eslint.codeAction.disableRuleComment": {
     "enable": true,
-    "location": "sameLine"
+    "location": "separateLine"
   },
   "eslint.codeAction.showDocumentation": {
     "enable": true
   },
   "eslint.enable": true,
-  "eslint.options": {
-    "resolvePluginsRelativeTo": "./node_modules/@ridedott/eslint-config"
-  },
+  "eslint.lintTask.enable": true,
   "eslint.run": "onType",
   "jest.autoEnable": false,
   "jest.pathToConfig": "./jest.config.js",

--- a/src/eventHandlers/checkSuite/index.spec.ts
+++ b/src/eventHandlers/checkSuite/index.spec.ts
@@ -315,7 +315,7 @@ describe('check Suite event handler', (): void => {
     await checkSuiteHandle(octokit, 'some-other-login');
 
     expect(infoSpy).toHaveBeenCalledWith(
-      'Pull request not created by some-other-login, skipping.',
+      'Pull request created by dependabot-preview[bot], not some-other-login, skipping.',
     );
   });
 

--- a/src/eventHandlers/checkSuite/index.ts
+++ b/src/eventHandlers/checkSuite/index.ts
@@ -110,7 +110,7 @@ const tryMerge = async (
     /*
      * cspell:ignore merlinnot
      *
-     * TODO(merlinnot) [2020-06-01] Start pulling the value once it reaches
+     * TODO(merlinnot) [2020-09-01] Start pulling the value once it reaches
      * GA.
      */
     mergeStateStatus !== undefined
@@ -142,7 +142,12 @@ export const checkSuiteHandle = async (
       typeof context.payload.sender !== 'object' ||
       context.payload.sender.login !== gitHubLogin
     ) {
-      logInfo(`Pull request not created by ${gitHubLogin}, skipping.`);
+      logInfo(
+        `Pull request created by ${
+          (context.payload.sender?.login as string | undefined) ??
+          'unknown sender'
+        }, not ${gitHubLogin}, skipping.`,
+      );
 
       return;
     }

--- a/src/eventHandlers/pullRequest/index.ts
+++ b/src/eventHandlers/pullRequest/index.ts
@@ -62,7 +62,11 @@ export const pullRequestHandle = async (
   }
 
   if (pullRequest.user.login !== gitHubLogin) {
-    logInfo(`Pull request not created by ${gitHubLogin}, skipping.`);
+    logInfo(
+      `Pull request created by ${
+        pullRequest.user.login as string
+      }, not ${gitHubLogin}, skipping.`,
+    );
 
     return;
   }

--- a/src/eventHandlers/push/index.spec.ts
+++ b/src/eventHandlers/push/index.spec.ts
@@ -233,7 +233,7 @@ describe('push event handler', (): void => {
     await pushHandle(octokit, 'some-other-login');
 
     expect(infoSpy).toHaveBeenCalledWith(
-      'Pull request not created by some-other-login, skipping.',
+      'Pull request created by dependabot-preview[bot], not some-other-login, skipping.',
     );
   });
 

--- a/src/eventHandlers/push/index.ts
+++ b/src/eventHandlers/push/index.ts
@@ -106,7 +106,11 @@ export const pushHandle = async (
   gitHubLogin: string,
 ): Promise<void> => {
   if (context.payload.pusher.name !== gitHubLogin) {
-    logInfo(`Pull request not created by ${gitHubLogin}, skipping.`);
+    logInfo(
+      `Pull request created by ${
+        context.payload.pusher.name as string
+      }, not ${gitHubLogin}, skipping.`,
+    );
 
     return;
   }


### PR DESCRIPTION
A more informative message should help users understand the mismatch in expectations better, allowing for easier self-debugging.

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.

<!--
Example: Resolves #1234

This allows PRs to be resolved automatically once the PR is merged to a base
branch. The following line should be removed if the PR does not affect any open
issues.
-->

Resolves #451 
