### PR TITLE
fix: verify actual PR author on CI event

### DIFF
--- a/src/eventHandlers/continuousIntegrationEnd/index.spec.ts
+++ b/src/eventHandlers/continuousIntegrationEnd/index.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import * as core from '@actions/core';
-import { context, getOctokit } from '@actions/github';
+import { getOctokit } from '@actions/github';
 import { StatusCodes } from 'http-status-codes';
 import * as nock from 'nock';
 
@@ -79,6 +79,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -130,6 +133,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -187,6 +193,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -239,6 +248,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -290,6 +302,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -342,6 +357,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'CLOSED',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -359,30 +377,56 @@ describe('continuous integration end event handler', (): void => {
   it('does not merge if request not created by the selected GITHUB_LOGIN and logs it', async (): Promise<void> => {
     expect.assertions(1);
 
+    const response: Response = {
+      data: {
+        repository: {
+          pullRequest: {
+            commits: {
+              edges: [
+                {
+                  node: {
+                    commit: {
+                      author: {
+                        name: DEPENDABOT_GITHUB_LOGIN,
+                      },
+                      message: COMMIT_MESSAGE,
+                      messageHeadline: COMMIT_HEADLINE,
+                    },
+                  },
+                },
+              ],
+            },
+            id: PULL_REQUEST_ID,
+            mergeable: 'MERGEABLE',
+            merged: false,
+            reviews: {
+              edges: [
+                {
+                  node: {
+                    state: 'APPROVED',
+                  },
+                },
+              ],
+            },
+            state: 'CLOSED',
+            title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
+          },
+        },
+      },
+    };
+
+    nock('https://api.github.com')
+      .post('/graphql')
+      .reply(StatusCodes.OK, response);
+
     await continuousIntegrationEndHandle(octokit, 'some-other-login', 3);
 
     expect(infoSpy).toHaveBeenCalledWith(
       'Pull request created by dependabot[bot], not some-other-login, skipping.',
     );
-  });
-
-  it('does not merge if request not created by the selected GITHUB_LOGIN and logs unknown sender if the sender is undefined', async (): Promise<void> => {
-    expect.assertions(1);
-
-    const { sender } = context.payload;
-    delete context.payload.sender;
-
-    await continuousIntegrationEndHandle(octokit, 'some-other-login', 3);
-
-    expect(infoSpy).toHaveBeenCalledWith(
-      'Pull request created by unknown sender, not some-other-login, skipping.',
-    );
-
-    /* eslint-disable require-atomic-updates */
-    /* eslint-disable immutable/no-mutation */
-    context.payload.sender = sender;
-    /* eslint-enable require-atomic-updates */
-    /* eslint-enable immutable/no-mutation */
   });
 
   it('does not merge if last commit was not created by the selected GITHUB_LOGIN and DISABLED_FOR_MANUAL_CHANGES is set to "true"', async (): Promise<void> => {
@@ -441,6 +485,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -493,6 +540,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -561,6 +611,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -627,6 +680,9 @@ describe('continuous integration end event handler', (): void => {
             },
             state: 'OPEN',
             title: 'bump @types/jest from 26.0.12 to 26.1.0',
+            user: {
+              name: 'dependabot[bot]',
+            }
           },
         },
       },
@@ -679,6 +735,9 @@ describe('continuous integration end event handler', (): void => {
               },
               state: 'OPEN',
               title: 'bump @types/jest from 26.0.12 to 27.0.13',
+              user: {
+                name: 'dependabot[bot]',
+              }
             },
           },
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,12 @@ export type ReviewEdges = Array<
   | undefined
 >;
 
+export interface GithubUser {
+  name: string;
+}
+
 export interface PullRequestInformationContinuousIntegrationEnd {
+  authorName: string;
   commitAuthorName: string;
   commitMessage: string;
   commitMessageHeadline: string;
@@ -42,9 +47,7 @@ interface PullRequest {
     edges: Array<{
       node: {
         commit: {
-          author: {
-            name: string;
-          };
+          author: GithubUser;
           message: string;
           messageHeadline: string;
         };
@@ -58,6 +61,7 @@ interface PullRequest {
   reviews: { edges: ReviewEdges };
   state: PullRequestState;
   title: string;
+  user: GithubUser;
 }
 
 export interface FindPullRequestsInfoByReferenceNameResponse {


### PR DESCRIPTION
The current implementation is not working for CI events, as it checks the event sender (e.g. last commit author) and not the PR author.