### PR TITLE
chore(deps-dev): bump @vercel/ncc from 0.30.0 to 0.31.1

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,10 +19,6 @@ updates:
       include: scope
       prefix: chore
     directory: /
-    ignore:
-      # https://github.com/ridedott/merge-me-action/issues/1098
-      - dependency-name: '@vercel/ncc'
-        versions: ['^0.31.0']
     open-pull-requests-limit: 99
     package-ecosystem: npm
     reviewers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/jest": "^27.0.1",
         "@types/micromatch": "^4.0.2",
         "@types/node": "^16.0.1",
-        "@vercel/ncc": "^0.30.0",
+        "@vercel/ncc": "^0.31.1",
         "commitizen": "^4.2.4",
         "cspell": "^5.9.1",
         "eslint": "^7.32.0",
@@ -2682,9 +2682,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.30.0.tgz",
-      "integrity": "sha512-16ePj2GkwjomvE0HLL5ny+d+sudOwvZNYW8vjpMh3cyWdFxoMI8KSQiolVxeHBULbU1C5mVxLK5nL9NtnnpIew==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.31.1.tgz",
+      "integrity": "sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -18806,9 +18806,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.30.0.tgz",
-      "integrity": "sha512-16ePj2GkwjomvE0HLL5ny+d+sudOwvZNYW8vjpMh3cyWdFxoMI8KSQiolVxeHBULbU1C5mVxLK5nL9NtnnpIew==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.31.1.tgz",
+      "integrity": "sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/jest": "^27.0.1",
     "@types/micromatch": "^4.0.2",
     "@types/node": "^16.0.1",
-    "@vercel/ncc": "^0.30.0",
+    "@vercel/ncc": "^0.31.1",
     "commitizen": "^4.2.4",
     "cspell": "^5.9.1",
     "eslint": "^7.32.0",


### PR DESCRIPTION
Vercel released a fixed version of `ncc`, so we can unblock updates again.

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.

<!--
Example: Resolves #1234

This allows PRs to be resolved automatically once the PR is merged to a base
branch. The following line should be removed if the PR does not affect any open
issues.
-->

Resolves #
