### PR TITLE
fix: update action to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,4 +44,4 @@ inputs:
 name: 'Merge me!'
 runs:
   main: dist/index.js
-  using: node12
+  using: node16


### PR DESCRIPTION
## Description

Node.js 12 actions are deprecated.

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.

Resolves errors I started to see on my repository, eg. https://github.com/arturoherrero/arturoherrero.com/actions/runs/3413619370
